### PR TITLE
update component & examples to use createClass and propTypes packages

### DIFF
--- a/examples/async-data/app.js
+++ b/examples/async-data/app.js
@@ -1,9 +1,10 @@
 import React from 'react'
+import createReactClass from 'create-react-class';
 import DOM from 'react-dom'
 import Autocomplete from '../../lib/index'
 import { getStates, styles, fakeRequest } from '../../lib/utils'
 
-let App = React.createClass({
+let App = createReactClass({
 
   getInitialState() {
     return {

--- a/examples/custom-menu/app.js
+++ b/examples/custom-menu/app.js
@@ -1,9 +1,10 @@
 import React from 'react'
 import DOM from 'react-dom'
+import createReactClass from 'create-react-class';
 import Autocomplete from '../../lib/index'
 import { getStates, styles, fakeRequest } from '../../lib/utils'
 
-let App = React.createClass({
+let App = createReactClass({
 
   getInitialState() {
     return {

--- a/examples/static-data/app.js
+++ b/examples/static-data/app.js
@@ -1,9 +1,10 @@
 import React from 'react'
-import DOM from 'react-dom'
+import createReactClass from 'create-react-class';
+import DOM from 'react-dom';
 import { getStates, matchStateToTerm, sortStates, styles } from '../../lib/utils'
 import Autocomplete from '../../lib/index'
 
-let App = React.createClass({
+let App = createReactClass({
   getInitialState() {
     return { value: 'Ma' }
   },

--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -1,5 +1,6 @@
 const React = require('react')
-const { PropTypes } = React
+import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
 const { findDOMNode } = require('react-dom')
 const scrollIntoView = require('dom-scroll-into-view')
 
@@ -15,7 +16,7 @@ const IMPERATIVE_API = [
   'setRangeText',
 ]
 
-let Autocomplete = React.createClass({
+let Autocomplete = createReactClass({
 
   propTypes: {
     /**

--- a/package.json
+++ b/package.json
@@ -54,10 +54,10 @@
     "lodash.flow": "^3.5.0",
     "lodash.map": "^4.6.0",
     "lodash.sortby": "^4.7.0",
-    "react": "^0.14.7",
-    "react-addons-test-utils": "^0.14.7",
+    "react": "https://registry.npmjs.org/react/-/react-15.5.4.tgz",
+    "react-addons-test-utils": "^15.5.1",
     "react-docgen": "^2.13.0",
-    "react-dom": "^0.14.7",
+    "react-dom": "https://registry.npmjs.org/react-dom/-/react-dom-15.5.4.tgz",
     "scripty": "^1.7.1",
     "st": "^1.2.0",
     "uglify-js": "^2.7.5",
@@ -72,11 +72,13 @@
   ],
   "keywords": [],
   "dependencies": {
-    "dom-scroll-into-view": "1.0.1"
+    "create-react-class": "^15.5.3",
+    "dom-scroll-into-view": "1.0.1",
+    "prop-types": "^15.5.10"
   },
   "peerDependencies": {
-    "react": "^0.14.7 || ^15.0.0-0",
-    "react-dom": "^0.14.7 || ^15.0.0-0"
+    "react": "15.5.4",
+    "react-dom": "15.5.4"
   },
   "jest": {
     "modulePathIgnorePatterns": [


### PR DESCRIPTION
- Upgrades to newer version of react
- Gets rid of deprecation warnings of using createClass & PropTypes directly from the React lib